### PR TITLE
Added aurelia-i18n and aurelia-validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .idea
 .DS_STORE
 output/
+typings

--- a/aurelia_project/aurelia.json
+++ b/aurelia_project/aurelia.json
@@ -136,7 +136,24 @@
             "path": "../node_modules/aurelia-testing/dist/amd",
             "main": "aurelia-testing",
             "env": "dev"
-          }
+          },
+          {
+  					"name": "i18next",
+  					"path": "../node_modules/i18next/dist/umd",
+  					"main": "i18next"
+  				}, {
+  					"name": "aurelia-i18n",
+  					"path": "../node_modules/aurelia-i18n/dist/amd",
+  					"main": "aurelia-i18n"
+  				}, {
+  					"name": "i18next-xhr-backend",
+  					"path": "../node_modules/i18next-xhr-backend/dist/umd",
+  					"main": "i18nextXHRBackend"
+  				}, {
+  					"name": "aurelia-validation",
+  					"path": "../node_modules/aurelia-validation/dist/amd",
+  					"main": "aurelia-validation"
+  				}
         ]
       }
     ]

--- a/index.html
+++ b/index.html
@@ -12,6 +12,6 @@
   </script>
 
   <body aurelia-app="main">
-    <script src="output\vendor-bundle.js" data-main="aurelia-bootstrapper"></script>
+    <script src="output/vendor-bundle.js" data-main="aurelia-bootstrapper"></script>
   </body>
 </html>

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -1,0 +1,14 @@
+{
+	"test": "Test",
+  "errorMessages": {
+		"default": "${$displayName} is invalid.",
+		"required": "${$displayName} is required.",
+		"matches": "${$displayName} is not correctly formatted.",
+		"email": "${$displayName} is not a valid email.",
+		"minLength": "${$displayName} must be at least ${$config.length} character ${$config.length === 1 ? '' : 's'}.",
+		"maxLength": "${$displayName} cannot be longer than ${$config.length} character ${$config.length === 1 ? '' : 's'}.",
+		"minItems": "${$displayName} must contain at least ${$config.count} item ${$config.count === 1 ? '' : 's'}.",
+		"maxItems": "${$displayName} cannot contain more than ${$config.count} item ${$config.count === 1 ? '' : 's'}.",
+		"equals": "${$displayName} must be ${$config.expectedValue}."
+	}
+}

--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -1,0 +1,14 @@
+{
+	"test": "Prueba",
+  "errorMessages": {
+		"default": "${$displayName} es inválido.",
+		"required": "${$displayName} es obligatorio",
+		"matches": "${$displayName} no tiene el formato correcto.",
+		"email": "${$displayName} no es un email válido.",
+		"minLength": "${$displayName} debe tener al menos ${$config.length} caracteres ${$config.length === 1 ? '' : 's'}.",
+		"maxLength": "${$displayName} no puede superar los ${$config.length} caracteres ${$config.length === 1 ? '' : 's'}.",
+		"minItems": "${$displayName} debe contener al menos ${$config.count} items ${$config.count === 1 ? '' : 's'}.",
+		"maxItems": "${$displayName} no puede contener mas de ${$config.count} items ${$config.count === 1 ? '' : 's'}.",
+		"equals": "${$displayName} debe ser ${$config.expectedValue}."
+	}
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "aurelia-animator-css": "^1.0.0",
     "aurelia-bootstrapper": "^1.0.0",
     "aurelia-fetch-client": "^1.0.0",
-    "electron": "^1.4.3"
+    "aurelia-i18n": "^1.1.2",
+    "aurelia-validation": "^0.13.1",
+    "electron": "^1.4.3",
+    "i18next-xhr-backend": "^1.2.0"
   },
   "peerDependencies": {},
   "devDependencies": {
@@ -50,6 +53,7 @@
     "vinyl-fs": "^2.4.3"
   },
   "scripts": {
-    "start": "electron ."
+    "start": "electron .",
+    "postinstall": "typings install"
   }
 }

--- a/source/app.html
+++ b/source/app.html
@@ -3,10 +3,10 @@
 	<window>
 		<dock-panel>
 			<div class="text">centre</div>
-			<div class="text" slot="top">top</div>
-			<div class="text" slot="bottom">bottom</div>
-			<div class="text" slot="left">left</div>
-			<div class="text" slot="right">right</div>
+			<div class="text" slot="top" click.delegate="sayHello()">top</div>
+			<div class="text" slot="bottom" click.delegate="sayHello()">bottom</div>
+			<div class="text" slot="left" click.delegate="sayHello()">left</div>
+			<div class="text" slot="right" click.delegate="sayHello()">right</div>
 		</dock-panel>
 	</window>
 </template>

--- a/source/app.ts
+++ b/source/app.ts
@@ -1,15 +1,20 @@
 import { remote } from 'electron';
-import { Page } from './models/page';
+import {I18N} from 'aurelia-i18n';
+import {inject} from 'aurelia-framework';
+import {Router, RouterConfiguration} from 'aurelia-router';
 
+
+@inject(I18N)
 export class App {
-  message = 'Hello World!';
-  pages = [
-    new Page("page 1", "pages/example-page"),
-  ];
+  private i18n: I18N;
+
+  constructor(i18n: I18N){
+    this.i18n = i18n;
+  }
 
   sayHello() {
     remote.dialog.showMessageBox({
-      message: this.message,
+      message: this.i18n.tr("test"),
       buttons: ["OK"]
     });
   }

--- a/source/main.ts
+++ b/source/main.ts
@@ -1,18 +1,58 @@
 import {Aurelia} from 'aurelia-framework'
+import {I18N} from 'aurelia-i18n';
+import {ValidationMessageProvider} from 'aurelia-validation';
 import environment from './environment';
+import * as Backend from 'i18next-xhr-backend';
+
+//Configure Bluebird Promises.
+//Note: You may want to use environment-specific configuration.
+// Promise.config({
+// 	warnings: {
+// 		wForgottenReturn: false
+// 	}
+// });
 
 export function configure(aurelia: Aurelia) {
   aurelia.use
     .standardConfiguration()
     .feature('elements');
-
+  //aurelia.use.feature('resources');
   if (environment.debug) {
     aurelia.use.developmentLogging();
   }
-
   if (environment.testing) {
     aurelia.use.plugin('aurelia-testing');
   }
+  aurelia.use.plugin('aurelia-validation');
+  // aurelia.use.plugin('aurelia-validatejs');
+  aurelia.use.plugin('aurelia-i18n', (instance) => {
+    // register backend plugin
+    instance.i18next.use(Backend);
 
-  aurelia.start().then(() => aurelia.setRoot());
+    // adapt options to your needs (see http://i18next.com/docs/options/)
+    // make sure to return the promise of the setup method, in order to guarantee proper loading
+    return instance.setup({
+      backend: { // <-- configure backend settings
+        loadPath: './locales/{{lng}}/{{ns}}.json' // <-- XHR settings for where to get the files from
+      },
+      //lng: 'es',
+      attributes: ['t', 'i18n'],
+      // ns: ['translation'],
+      //defaultNS: 'translation',
+      fallbackLng: 'en',
+      debug: true
+    });
+  });
+
+  const i18n = aurelia.container.get(I18N);
+  ValidationMessageProvider.prototype.getMessage = function(key) {
+    const translation = i18n.tr(`errorMessages.${key}`);
+    return this.parser.parseMessage(translation);
+  };
+
+  ValidationMessageProvider.prototype.getDisplayName = function(propertyName) {
+    return i18n.tr(propertyName);
+  };
+
+  aurelia.start().then(() => {return aurelia.setRoot()});
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,13 +10,16 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "moduleResolution": "node",
-    "lib": ["es2015", "dom"]
+    "lib": ["es2015", "dom"],
+    "allowSyntheticDefaultImports": true
   },
   "exclude": [
     "node_modules"
   ],
   "filesGlob": [
-    "./source/**/*.ts"
+    "./source/**/*.ts",
+    "./typings/**/*.ts",
+    "./vendor_typings/**/*.ts"
   ],
   "atom": {
     "rewriteTsconfig": false

--- a/typings.json
+++ b/typings.json
@@ -4,7 +4,11 @@
   "globalDevDependencies": {
     "angular-protractor": "registry:dt/angular-protractor#1.5.0+20160425143459",
     "jasmine": "registry:dt/jasmine#2.2.0+20160505161446",
-    "selenium-webdriver": "registry:dt/selenium-webdriver#2.44.0+20160317120654",
-    "node": "registry:dt/node"
+    "node": "registry:dt/node",
+    "selenium-webdriver": "registry:dt/selenium-webdriver#2.44.0+20160317120654"
+  },
+  "globalDependencies": {
+    "i18next": "registry:dt/i18next#2.3.4+20160803175212",
+    "i18next-xhr-backend": "file:./vendor_typings/i18next-xhr-backend.d.ts"
   }
 }

--- a/vendor_typings/i18next-xhr-backend.d.ts
+++ b/vendor_typings/i18next-xhr-backend.d.ts
@@ -1,0 +1,27 @@
+declare module 'i18next-xhr-backend' {
+
+    interface Interpolator {
+        interpolate: () => string
+    }
+    interface Services {
+        interpolator: Interpolator
+    }
+    export class Backend {
+        type: 'backend';
+        services: Services;
+        options: {
+            loadPath: string,
+            addPath:  string,
+            allowMultiLoading: boolean,
+            parse: () => {},
+            crossDomain: boolean,
+            ajax: () => void
+        };
+        constructor(services: Services, options?: {});
+        init(services: Services, options?: {}): void;
+        readMulti(languages: Array<any>, namespaces: Array<any>, callback: () => void): void;
+        read(language: {}, namespace: {}, callback: () => void): void;
+        loadUrl(url: string, callback: () => void): void;
+        create(languages: any[], namespace: string, key: string, fallbackValue: string): void;
+    }
+}


### PR DESCRIPTION
If you are interested, I've added the necessary configuration to use **aurelia-i18n** as well as **aurelia-validation**.

A sample usage of **aurelia-i18n** is provided, but the proper locale should be configured using the system's locale; since this is a working example, it uses the default locale.

I could not make any example with **aurelia-validation** (although I did test this configuration in another working project) but I've wrote all the boilerplate code.

If you are not interested in these features, you may simple discard this PR.
