### PR TITLE
added vscode tasks

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,8 +5,12 @@
       "name": "Debug",
       "type": "chrome",
       "request": "launch",
-      "port": 9222,      
-      "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron.cmd",
+      "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron",
+      "windows": {
+        "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron.cmd"
+      },
+      "preLaunchTask": "build",
+      "port": 9222,
       "runtimeArgs": [
         "${workspaceRoot}",
         "--enable-logging",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,30 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "0.1.0",
+  "command": "au",
+  "isShellCommand": true,
+  "tasks": [
+    {
+      "taskName": "build",
+      "isBuildCommand": true
+    },
+    {
+      "taskName": "build:watch",
+      "isBuildCommand": true,
+      "isWatching": true
+    },
+    {
+      "taskName": "test",
+      "isTestCommand": true
+    },
+    {
+      "taskName": "test:watch",
+      "isWatching": true,
+      "args": [
+        "-w"
+      ]
+    }
+  ],
+  "showOutput": "always"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -10,20 +10,8 @@
       "isBuildCommand": true
     },
     {
-      "taskName": "build:watch",
-      "isBuildCommand": true,
-      "isWatching": true
-    },
-    {
       "taskName": "test",
       "isTestCommand": true
-    },
-    {
-      "taskName": "test:watch",
-      "isWatching": true,
-      "args": [
-        "-w"
-      ]
     }
   ],
   "showOutput": "always"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ au run
 ```
 **build (vscode)**
 * press Ctrl+Shift+B
-* or select a task from the task menu (normal or watch)
+* or select a task from the task menu
 **debug (vscode):**
 * add breakpoints
 * press f5. 
@@ -32,4 +32,4 @@ au test --watch
 ```
 **test (vscode)**
 * press Ctrl+Shift+B
-* then select a test from the task menu (normal or watch)
+* then select a test from the task menu

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ requires:
 npm install
 au run
 ```
-
+**build (vscode)**
+* press Ctrl+Shift+B
+* or select a task from the task menu (normal or watch)
 **debug (vscode):**
-* build 
 * add breakpoints
 * press f5. 
 
@@ -29,3 +30,6 @@ Once the app is build, you may execute:
 ```shell
 au test --watch
 ```
+**test (vscode)**
+* press Ctrl+Shift+B
+* then select a test from the task menu (normal or watch)

--- a/aurelia_project/tasks/transpile.ts
+++ b/aurelia_project/tasks/transpile.ts
@@ -35,7 +35,7 @@ function buildTypeScript() {
   return eventStream.merge(dts, src)
     .pipe(plumber({ errorHandler: notify.onError('Error: <%= error.message %>') }))
     .pipe(sourcemaps.init())
-    .pipe(ts(typescriptCompiler))
+    .pipe(typescriptCompiler())
     .pipe(build.bundle());
 }
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "aurelia-i18n": "^1.1.2",
     "aurelia-validation": "^0.13.1",
     "electron": "^1.4.3",
-    "i18next-xhr-backend": "^1.2.0"
+    "i18next-xhr-backend": "^1.2.0",
+    "requirejs": "~2.3.2"
   },
   "peerDependencies": {},
   "devDependencies": {
@@ -50,8 +51,8 @@
     "spectron": "^3.4.0",
     "text": "github:requirejs/text",
     "through2": "^2.0.1",
-    "tslint": "^3.11.0",
-    "typescript": "~2.0.3",
+    "tslint": "~4.0.2",
+    "typescript": "^2.1.4",
     "typings": "^1.3.0",
     "uglify-js": "^2.6.3",
     "vinyl-fs": "^2.4.3"


### PR DESCRIPTION
Hello!
I added some tasks for vscode to make the debug process a little but lazier (no more au build, F5)
just press F5 and it will build sources before launching the electron shell, also made windows specific command so Linux & OSX users benefit from the F5 key
also updated typescript dep (async/await yay 😃 )