### PR TITLE
watch tasks and window button events

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,11 @@
   "version": "0.1.0",
   "command": "au",
   "isShellCommand": true,
+  "showOutput": "always",
   "tasks": [
+    {
+      "taskName": "run"
+    },
     {
       "taskName": "build",
       "isBuildCommand": true
@@ -12,7 +16,35 @@
     {
       "taskName": "test",
       "isTestCommand": true
+    },
+    {
+      "taskName": "run:watch",
+      "isWatching": true,
+      "args": [
+        "run",
+        "--watch"
+      ],
+      "suppressTaskName": true
+    },
+    {
+      "taskName": "build:watch",
+      "isWatching": true,
+      "isBuildCommand": true,
+      "args": [
+        "build",
+        "--watch"
+      ],
+      "suppressTaskName": true
+    },
+    {
+      "taskName": "test:watch",
+      "isWatching": true,
+      "isTestCommand": true,
+      "args": [
+        "test",
+        "--watch"
+      ],
+      "suppressTaskName": true
     }
-  ],
-  "showOutput": "always"
+  ]
 }

--- a/source/elements/window.html
+++ b/source/elements/window.html
@@ -9,22 +9,22 @@
 					<use xlink:href="./resources/symbols.svg#icon-config"></use>
 				</svg>
 			</button>
-			<button id="help-btn">
+			<button id="help-btn" click.delegate="showHelp()">
 				<svg class="icon icon-help">
 					<use xlink:href="./resources/symbols.svg#icon-help"></use>
 				</svg>
 			</button>
-			<button id="min-btn">
+			<button id="min-btn" click.delegate="minimizeWindow()">
 				<svg class="icon icon-minimise">
 					<use xlink:href="./resources/symbols.svg#icon-minimise" />
 				</svg>
 			</button>
-			<button id="max-btn">
+			<button id="max-btn" click.delegate="maximizeWindow()">
 				<svg class="icon icon-maximise">
 					<use xlink:href="./resources/symbols.svg#icon-maximise"></use>
 				</svg>
 			</button>
-			<button id="close-btn">
+			<button id="close-btn" click.delegate="tryCloseWindow()">
 				<svg class="icon icon-close">
 					<use xlink:href="./resources/symbols.svg#icon-close"></use>
 				</svg>

--- a/source/elements/window.ts
+++ b/source/elements/window.ts
@@ -1,42 +1,28 @@
 import { remote } from 'electron';
 
 export class Window {
-  title:string = "App";
-  
+  title: string = "App";
+
   constructor() {
-  }
-
-  attached() {
-    document.getElementById("min-btn").addEventListener("click", (e) => {
-      var window: Electron.BrowserWindow = remote.getCurrentWindow();
-      window.minimize();
-    });
-
-    document.getElementById("max-btn").addEventListener("click", (e) => {
-      var window: Electron.BrowserWindow = remote.getCurrentWindow();
-
-      if (window.isMaximized())
-        window.unmaximize();
-      else
-        window.maximize();
-    });
-
-    document.getElementById("close-btn").addEventListener("click", (e) => {
-      this.tryCloseWindow();
-    });
-
-    document.getElementById("help-btn").addEventListener("click", (e) => {
-      this.showHelp();
-    });
   }
 
   tryCloseWindow() {
     this.closeWindow();
   }
 
+  minimizeWindow() {
+    var window: Electron.BrowserWindow = remote.getCurrentWindow();
+    window.minimize();
+  }
+
+  maximizeWindow() {
+    var window: Electron.BrowserWindow = remote.getCurrentWindow();
+    if (window.isMaximized()) { window.unmaximize(); }
+    else { window.maximize(); }
+  }
+
   closeWindow() {
     var window: Electron.BrowserWindow = remote.getCurrentWindow();
-
     window.close();
   }
 


### PR DESCRIPTION
as I mentioned in #12  this pr aims to add watch tasks of vscode not just build but test and run in watch mode.
as well as my take on #11 it is a fairly easy change but since I'm quite new to Aurelia perhaps my approach is not good at all. also I was wondering in my mind that given close button closes the window in non Darwin platforms, it could have an event aggregator that fires a closing event, to make other components aware that the window is closing?